### PR TITLE
Signer attachments

### DIFF
--- a/src/main/java/com/hellosign/sdk/resource/SignatureRequest.java
+++ b/src/main/java/com/hellosign/sdk/resource/SignatureRequest.java
@@ -6,6 +6,7 @@ import com.hellosign.sdk.resource.support.FormField;
 import com.hellosign.sdk.resource.support.ResponseData;
 import com.hellosign.sdk.resource.support.Signature;
 import com.hellosign.sdk.resource.support.Signer;
+import com.hellosign.sdk.resource.support.Attachment;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +38,32 @@ public class SignatureRequest extends AbstractRequest {
     public static final String SIGREQ_SIGNING_URL = "signing_url";
     public static final String SIGREQ_DETAILS_URL = "details_url";
     public static final String SIGREQ_IS_DECLINED = "is_declined";
+    public static final String SIGREQ_ATTACHMENTS = "attachments";
+    public static final String SIGREQ_ATTACHMENTS_NAME = "name";
+    public static final String SIGREQ_ATTACHMENTS_INSTRUCTIONS = "instructions";
+    public static final String SIGREQ_ATTACHMENTS_INDEX = "signer_index";
+    public static final String SIGREQ_ATTACHMENTS_REQUIRED = "required";
+
 
     public static final String SIGREQ_FORMAT_ZIP = "zip";
     public static final String SIGREQ_FORMAT_PDF = "pdf";
 
     // Fields specific to request
     private List<Signer> signers = new ArrayList<Signer>();
+
+    private List<Attachment> attachments = new ArrayList<>();
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    public List<Attachment> getAttachmentsInResponse(){
+        return getList(Attachment.class, SIGREQ_ATTACHMENTS);
+    }
+
+    public void setAttachments(List<Attachment> attachments){
+        this.attachments = attachments;
+    }
 
     public SignatureRequest() {
         super();
@@ -255,6 +276,14 @@ public class SignatureRequest extends AbstractRequest {
                     fields.put(SIGREQ_SIGNERS + "[" + i + "][" + SIGREQ_SIGNER_PIN + "]",
                         s.getAccessCode());
                 }
+            }
+            List<Attachment> attachmentList = getAttachments();
+            for(int i=0; i<attachmentList.size(); i++){
+                Attachment attachment = attachmentList.get(i);
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_NAME + "]", attachment.getName());
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_INSTRUCTIONS + "]", attachment.getInstructions());
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_INDEX + "]", attachment.getSigner_index());
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_REQUIRED+ "]",attachment.isRequired());
             }
             List<String> ccz = getCCs();
             for (int i = 0; i < ccz.size(); i++) {

--- a/src/main/java/com/hellosign/sdk/resource/TemplateDraft.java
+++ b/src/main/java/com/hellosign/sdk/resource/TemplateDraft.java
@@ -1,6 +1,7 @@
 package com.hellosign.sdk.resource;
 
 import com.hellosign.sdk.HelloSignException;
+import com.hellosign.sdk.resource.support.Attachment;
 import com.hellosign.sdk.resource.support.CustomField;
 import com.hellosign.sdk.resource.support.Document;
 import com.hellosign.sdk.resource.support.types.FieldType;
@@ -25,6 +26,11 @@ public class TemplateDraft extends AbstractRequest {
     public static final String TEMPLATE_DRAFT_ID = "template_id";
     public static final String TEMPLATE_EDIT_URL = "edit_url";
     public static final String TEMPLATE_EXPIRES_AT = "expires_at";
+    public static final String SIGREQ_ATTACHMENTS = "attachments";
+    public static final String SIGREQ_ATTACHMENTS_NAME = "name";
+    public static final String SIGREQ_ATTACHMENTS_INSTRUCTIONS = "instructions";
+    public static final String SIGREQ_ATTACHMENTS_INDEX = "signer_index";
+    public static final String SIGREQ_ATTACHMENTS_REQUIRED = "required";
 
     private List<String> ccRoles = new ArrayList<>();
     private List<String> signerRoles = new ArrayList<>();
@@ -36,6 +42,21 @@ public class TemplateDraft extends AbstractRequest {
 
     public TemplateDraft(JSONObject json) throws HelloSignException {
         super(json, TEMPLATE_DRAFT_KEY);
+    }
+
+    // List of Attachment
+    private List<Attachment> attachments = new ArrayList<>();
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    /**
+     * Set List of Attachments to the request.
+     * @param attachments
+     */
+    public void setAttachments(List<Attachment> attachments) {
+        this.attachments = attachments;
     }
 
     /**
@@ -259,6 +280,14 @@ public class TemplateDraft extends AbstractRequest {
                 if (getOrderMatters()) {
                     fields.put("signer_roles[" + i + "][order]", i);
                 }
+            }
+            List<Attachment> attachmentList = getAttachments();
+            for(int i=0; i<attachmentList.size(); i++){
+                Attachment attachment = attachmentList.get(i);
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_NAME + "]", attachment.getName());
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_INSTRUCTIONS + "]", attachment.getInstructions());
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_INDEX + "]", attachment.getSigner_index());
+                fields.put(SIGREQ_ATTACHMENTS + "[" + i + "][" + SIGREQ_ATTACHMENTS_REQUIRED+ "]",attachment.isRequired());
             }
 
             List<String> ccRoles = getCCRoles();

--- a/src/main/java/com/hellosign/sdk/resource/support/Attachment.java
+++ b/src/main/java/com/hellosign/sdk/resource/support/Attachment.java
@@ -1,0 +1,82 @@
+package com.hellosign.sdk.resource.support;
+
+public class Attachment {
+    String name;
+    String instructions;
+    int signer_index;
+    boolean isRequired;
+    int signer;
+
+    public Attachment(){
+    }
+
+    /***
+     * Method to add/request attachments with Signature Request.
+     * @param name : Signer name
+     * @param instructions : Instruction for Signer
+     * @param signer_index : Signer Index (It should be in accordance with signer's order: first signer is 0, second is
+     *                    1 and so on.. )
+     * @param isRequired : Whether it is mandatory or not.
+     */
+    public Attachment(String name, String instructions, int signer_index, boolean isRequired){
+      setName(name);
+      setInstructions(instructions);
+      setSigner_index(signer_index);
+      setRequired(isRequired);
+    }
+
+    /**
+     * Get Instruction for signer.
+     * @return
+     */
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public void setInstructions(String instructions) {
+        if(!instructions.isBlank()){
+            this.instructions = instructions;
+        }
+    }
+
+    public int getSigner() {
+        return signer;
+    }
+
+    /**
+     * Provide signer_index, in accordance to the order, signer is added.
+     * Example : first signer : signer_index = 0
+     *           second signer : signer_index = 1
+     * @param signer_index
+     */
+    public void setSigner_index(int signer_index) {
+            this.signer_index= signer_index;
+    }
+
+    public int getSigner_index() {
+        return signer_index;
+    }
+
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public void setRequired(boolean required) {
+        if(required){
+            isRequired = required;
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        if(!name.isBlank()){
+            this.name = name;
+        }
+    }
+
+}
+

--- a/src/test/resources/HelloSignClientTest/testCreateEmbeddedRequestWithAttachment.json
+++ b/src/test/resources/HelloSignClientTest/testCreateEmbeddedRequestWithAttachment.json
@@ -1,0 +1,59 @@
+{
+  "signature_request":{
+    "signature_request_id":"3cb8286f6ee3770aa7c5670e035362e62245f129",
+    "test_mode":true,
+    "title":"pdf-test",
+    "original_title":"pdf-test",
+    "subject":null,
+    "message":null,
+    "metadata":{
+      "test_key":"test_value"
+    },
+    "created_at":1589207125,
+    "attachments":[
+      {
+        "id":"92376dfb14fb3698faf17592ce731368295f8140",
+        "signer":1,
+        "name":"License",
+        "instructions":"Pl provide copy of license.",
+        "required":true,
+        "uploaded_at":null
+      }
+    ],
+    "is_complete":false,
+    "is_declined":false,
+    "has_error":false,
+    "custom_fields":[
+
+    ],
+    "response_data":[
+
+    ],
+    "signing_url":null,
+    "signing_redirect_url":null,
+    "final_copy_uri":"\/v3\/signature_request\/final_copy\/3cb8286f6ee3770aa7c5670e035362e62245f129",
+    "files_url":"https:\/\/api.hellosign.com\/v3\/signature_request\/files\/3cb8286f6ee3770aa7c5670e035362e62245f129",
+    "details_url":"https:\/\/app.hellosign.com\/home\/manage?guid=3cb8286f6ee3770aa7c5670e035362e62245f129",
+    "requester_email_address":"vaibhavij+prd@hellosign.com",
+    "signatures":[
+      {
+        "signature_id":"5bfaf1af15b13f7f3fe57361e78577fd",
+        "has_pin":false,
+        "signer_email_address":"vaibhavij+stg@hellosign.com",
+        "signer_name":"Chris",
+        "signer_role":null,
+        "order":null,
+        "status_code":"awaiting_signature",
+        "signed_at":null,
+        "last_viewed_at":null,
+        "last_reminded_at":null,
+        "error":null
+      }
+    ],
+    "cc_email_addresses":[
+
+    ],
+    "template_ids":null,
+    "client_id":"82d8101db9a2147f8e07244f9ca030a6"
+  }
+}

--- a/src/test/resources/HelloSignClientTest/testSendSignatureRequestWithAttachment.json
+++ b/src/test/resources/HelloSignClientTest/testSendSignatureRequestWithAttachment.json
@@ -1,0 +1,79 @@
+{
+  "signature_request":{
+    "signature_request_id":"12d7f30ac9a6330c8d84a3787c18416f02ed9aae",
+    "test_mode":true,
+    "title":"From Vaibhavi",
+    "original_title":"From Vaibhavi",
+    "subject":"From Vaibhavi",
+    "message":"Pls sign",
+    "metadata":{
+
+    },
+    "created_at":1589207028,
+    "attachments":[
+      {
+        "id":"da7632a961a30094fcd99c5bea027251bead6a63",
+        "signer":1,
+        "name":"License",
+        "instructions":"Pl provide copy of license.",
+        "required":true,
+        "uploaded_at":null
+      },
+      {
+        "id":"c07a33a556d45a529982b6364ab43a55049c9338",
+        "signer":2,
+        "name":"California Id",
+        "instructions":"Pl provide copy of California Id.",
+        "required":true,
+        "uploaded_at":null
+      }
+    ],
+    "is_complete":false,
+    "is_declined":false,
+    "has_error":false,
+    "custom_fields":[
+
+    ],
+    "response_data":[
+
+    ],
+    "signing_url":"https:\/\/app.hellosign.com\/sign\/12d7f30ac9a6330c8d84a3787c18416f02ed9aae",
+    "signing_redirect_url":null,
+    "final_copy_uri":"\/v3\/signature_request\/final_copy\/12d7f30ac9a6330c8d84a3787c18416f02ed9aae",
+    "files_url":"https:\/\/api.hellosign.com\/v3\/signature_request\/files\/12d7f30ac9a6330c8d84a3787c18416f02ed9aae",
+    "details_url":"https:\/\/app.hellosign.com\/home\/manage?guid=12d7f30ac9a6330c8d84a3787c18416f02ed9aae",
+    "requester_email_address":"vaibhavij+prd@hellosign.com",
+    "signatures":[
+      {
+        "signature_id":"0d7c0800db99166fcca56e6d377a57e3",
+        "has_pin":false,
+        "signer_email_address":"vaibhavij+stg@hellosign.com",
+        "signer_name":"Vaibhavi Joshi",
+        "signer_role":null,
+        "order":null,
+        "status_code":"awaiting_signature",
+        "signed_at":null,
+        "last_viewed_at":null,
+        "last_reminded_at":null,
+        "error":null
+      },
+      {
+        "signature_id":"7700d62c37eb5be7726df518a5de50db",
+        "has_pin":false,
+        "signer_email_address":"vaibhavij+stg1@hellosign.com",
+        "signer_name":"Vaibhavi",
+        "signer_role":null,
+        "order":null,
+        "status_code":"awaiting_signature",
+        "signed_at":null,
+        "last_viewed_at":null,
+        "last_reminded_at":null,
+        "error":null
+      }
+    ],
+    "cc_email_addresses":[
+
+    ],
+    "template_ids":null
+  }
+}


### PR DESCRIPTION
support for signers attachment : 
POST /signature_request/send
POST /signature_request/create_embedded
POST /template/create_embedded_draft
POST /unclaimed_draft/create_embedded end points. 

Verified/test all four points for attachment support. 