### PR TITLE
add method to query for signature requests

### DIFF
--- a/src/main/java/com/hellosign/sdk/HelloSignClient.java
+++ b/src/main/java/com/hellosign/sdk/HelloSignClient.java
@@ -88,6 +88,7 @@ public class HelloSignClient {
 
     public static final String PARAM_FILE_TYPE_URI = "file_type";
     public static final String PARAM_GET_URL = "get_url";
+    public static final String PARAM_QUERY = "query";
     public static final String FINAL_COPY_FILE_NAME = "final-copy";
     public static final String FINAL_COPY_FILE_EXT = "pdf";
     public static final String FILES_FILE_NAME = "files";
@@ -458,6 +459,26 @@ public class HelloSignClient {
             httpClient.withAuth(auth)
                 .withGetParam(AbstractResourceList.PAGE, Integer.toString(page))
                 .withGetParam(AbstractResourceList.PAGE_SIZE, Integer.toString(pageSize))
+                .get(BASE_URI + SIGNATURE_REQUEST_LIST_URI).asJson());
+    }
+
+    /**
+     * Retrieves a specific page of the current user's signature requests.
+     *
+     * @param page int
+     * @param pageSize int Must be between 1 and 100.
+     * @param query String that includes search terms and/or fields to be used to filter the SignatureRequest objects.
+     * @return SignatureRequestList
+     * @throws HelloSignException thrown if there's a problem processing the HTTP request or the
+     * JSON response.
+     */
+    public SignatureRequestList getSignatureRequests(int page, int pageSize, String query)
+        throws HelloSignException {
+        return new SignatureRequestList(
+            httpClient.withAuth(auth)
+                .withGetParam(AbstractResourceList.PAGE, Integer.toString(page))
+                .withGetParam(AbstractResourceList.PAGE_SIZE, Integer.toString(pageSize))
+                .withGetParam(PARAM_QUERY, query)
                 .get(BASE_URI + SIGNATURE_REQUEST_LIST_URI).asJson());
     }
 


### PR DESCRIPTION
The API offers an option to query for signature requests that match a certain criteria

https://app.hellosign.com/api/reference#list_signature_requests

So you could create a request like https://api.hellosign.com/v3//signature_request/list?query=complete:false&page_size=100

However the Java API does not have an option to include the query parameter. I've added that here, but it begs another question if there should either be a SignatureRequestsRequestobject that you pass in 

`getSignatureRequests(SignatureRequestsRequest requst)`

Where SignatureRequestsRequest contains page_size,page,query,account_id and adds them to the URL as query params if they are set, or

`getSignatureRequests(Map<String,Object> params)`

Where you just iterate through the entries and add them as key and value.toString

I'm not seeing any established conventions for this currently.

Stripe for instance uses something like

```
  Map<String, Object> params = new HashMap<String, Object>();
        params.put("expand", Lists.newArrayList("data.balance_transaction"));
        params.put("created", createdParams);
        params.put("limit", 100);
Charge.list(params)
```

Probably makes the most sense to do something like the below since `.withGetParams(params)` already exists on the HttpClient

```
public SignatureRequestList getSignatureRequests(Map<String, String> params) throws HelloSignException {       
        return new SignatureRequestList(httpClient.withAuth(auth).withGetParams(params).asJson());
    }
  ```

And then convert the existing methods to use it.

```  
    public SignatureRequestList getSignatureRequests(int page) throws HelloSignException {
        HashMap<String,String> params = new HashMap<>();
        params.put(AbstractResourceList.PAGE, Integer.toString(page));
        return getSignatureRequests(params);
    }

 public SignatureRequestList getSignatureRequests(int page, int pageSize)
        throws HelloSignException {
        HashMap<String,String> params = new HashMap<>();
        params.put(AbstractResourceList.PAGE, Integer.toString(page));
        params.put(AbstractResourceList.PAGE_SIZE, Integer.toString(pageSize));
        return getSignatureRequests(params);
    }
```

If you think that is a good path I can update the PR
