### PR TITLE
Cross compile for Java 8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 8, 9, 10, 11, 12, 13, 14, 15 ]
+        java: [ 10, 11, 12, 13, 14, 15 ]
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 Get your Java app connected to HelloSign's API in jiffy.
 
+To build this project you'll need JDK 9+ but the release artifacts support JRE 8+.
+
 ## Installing
 
 SDK releases are published to Maven's [Central repository](https://repo1.maven.org/maven2/com/hellosign/hellosign-java-sdk/):

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'signing'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+    options.compilerArgs.addAll(['--release', '8']) // for java 8 cross-compilation
 }
 
 task javadocJar(type: Jar) {


### PR DESCRIPTION
Fixing an issue, 5.2.0 was supposed to support Java 8 but we weren't cross compiling correctly. 5.2.1 should work with Java 8+