### PR TITLE
add a method to return the created_at value from a signature request

### DIFF
--- a/src/main/java/com/hellosign/sdk/resource/SignatureRequest.java
+++ b/src/main/java/com/hellosign/sdk/resource/SignatureRequest.java
@@ -8,6 +8,7 @@ import com.hellosign.sdk.resource.support.Signature;
 import com.hellosign.sdk.resource.support.Signer;
 import com.hellosign.sdk.resource.support.Attachment;
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ public class SignatureRequest extends AbstractRequest {
 
     public static final String SIGREQ_KEY = "signature_request";
     public static final String SIGREQ_ID = "signature_request_id";
+    public static final String SIGREQ_CREATED_AT = "created_at";
     public static final String SIGREQ_SIGNERS = "signers";
     public static final String SIGREQ_SIGNER_EMAIL = "email_address";
     public static final String SIGREQ_SIGNER_NAME = "name";
@@ -92,6 +94,20 @@ public class SignatureRequest extends AbstractRequest {
      */
     public boolean hasId() {
         return has(SIGREQ_ID);
+    }
+
+    /**
+     * Returns the {@code Instant} that this request was created.
+     * @return Instant the request was created or null if not created yet
+     */
+    public Instant getCreatedAt() {
+        Long value = getLong(SIGREQ_CREATED_AT);
+        if (value != null) {
+            return Instant.ofEpochSecond(value);
+        }
+        else {
+            return null;
+        }
     }
 
     /**

--- a/src/test/java/com/hellosign/sdk/HelloSignClientTest.java
+++ b/src/test/java/com/hellosign/sdk/HelloSignClientTest.java
@@ -44,6 +44,10 @@ import com.hellosign.sdk.resource.support.types.UnclaimedDraftType;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -303,6 +307,8 @@ public class HelloSignClientTest {
         SignatureRequest request = client.getSignatureRequest(id);
         assertNotNull(request);
         assertEquals(id, request.getId());
+        assertEquals(LocalDate.of(2022, Month.FEBRUARY, 11),
+            LocalDateTime.ofInstant(request.getCreatedAt(), ZoneId.of("UTC")).toLocalDate());
     }
 
     @Test(expected = HelloSignException.class)

--- a/src/test/resources/HelloSignClientTest/testGetSignatureRequest.json
+++ b/src/test/resources/HelloSignClientTest/testGetSignatureRequest.json
@@ -8,6 +8,7 @@
     "message": null,
     "metadata": {
     },
+    "created_at": 1644606159,
     "is_complete": false,
     "is_declined": false,
     "has_error": false,

--- a/src/test/resources/HelloSignClientTest/testGetSignatureRequests.json
+++ b/src/test/resources/HelloSignClientTest/testGetSignatureRequests.json
@@ -15,6 +15,7 @@
       "message": "Hello, world!",
       "metadata": {
       },
+      "created_at": 1644606159,
       "is_complete": true,
       "is_declined": false,
       "has_error": false,
@@ -62,6 +63,7 @@
       "message": null,
       "metadata": {
       },
+      "created_at": 1644606159,
       "is_complete": false,
       "is_declined": false,
       "has_error": false,

--- a/src/test/resources/HelloSignClientTest/testGetSignatureRequestsPage.json
+++ b/src/test/resources/HelloSignClientTest/testGetSignatureRequestsPage.json
@@ -62,6 +62,7 @@
       "message": null,
       "metadata": {
       },
+      "created_at": 1644606159,
       "is_complete": false,
       "is_declined": false,
       "has_error": false,

--- a/src/test/resources/HelloSignClientTest/testUpdateSignatureRequest.json
+++ b/src/test/resources/HelloSignClientTest/testUpdateSignatureRequest.json
@@ -8,6 +8,7 @@
     "message": null,
     "metadata": {
     },
+    "created_at": 1644606159,
     "is_complete": false,
     "is_declined": false,
     "has_error": false,


### PR DESCRIPTION
When doing audits on outstanding signature requests via the API it would be useful to access the created_at value.

The added method returns a `java.time.Instant` as that would be the best way to return the seconds since epoch and makes it easier for the developer to convert it to a relevant time on their end using the standard java date/time library.

I would be happy to convert the other methods that currently return the old `java.util.Date` to the modern `java.time.Instant`