### PR TITLE
Allow updating of signer name

### DIFF
--- a/src/main/java/com/hellosign/sdk/HelloSignClient.java
+++ b/src/main/java/com/hellosign/sdk/HelloSignClient.java
@@ -513,11 +513,12 @@ public class HelloSignClient {
      * JSON response.
      */
     public SignatureRequest updateSignatureRequest(String signatureRequestId, String signatureId,
-        String newEmailAddress) throws HelloSignException {
+        String newEmailAddress, String newSignerName) throws HelloSignException {
         String url = BASE_URI + SIGNATURE_REQUEST_UPDATE_URI + "/" + signatureRequestId;
         return new SignatureRequest(
             httpClient.withAuth(auth).withPostField(Signature.SIGNATURE_ID, signatureId)
-                .withPostField(SignatureRequest.SIGREQ_SIGNER_EMAIL, newEmailAddress).post(url)
+                .withPostField(SignatureRequest.SIGREQ_SIGNER_EMAIL, newEmailAddress)
+                .withPostField(SignatureRequest.SIGREQ_SIGNER_NAME, newSignerName).post(url)
                 .asJson());
     }
 

--- a/src/test/java/com/hellosign/sdk/HelloSignClientTest.java
+++ b/src/test/java/com/hellosign/sdk/HelloSignClientTest.java
@@ -469,11 +469,12 @@ public class HelloSignClientTest {
         String id = "5fd97d3b6a2ac509b7837891d8c804e29cc35636";
         String signatureId = "c390fac7bb23c2b48e6314272ec9db17";
         String newEmailAddress = "barack@obama.com";
+        String newSignerName = "Barack";
         SignatureRequest updatedReq = client
-            .updateSignatureRequest(id, signatureId, newEmailAddress);
+            .updateSignatureRequest(id, signatureId, newEmailAddress, newSignerName);
         assertNotNull(updatedReq);
         assertEquals(id, updatedReq.getId());
-        Signature sig = updatedReq.getSignature(newEmailAddress, "Barack");
+        Signature sig = updatedReq.getSignature(newEmailAddress, newSignerName);
         assertNotNull(sig);
         assertEquals(signatureId, sig.getId());
     }
@@ -484,7 +485,8 @@ public class HelloSignClientTest {
         String id = "84f8767b525611511ed24e5eaacee537589a30be";
         String signatureId = "e477e554af09555eea762d1c204d9f3d";
         String newEmailAddress = "nightman@hotmail.com";
-        client.updateSignatureRequest(id, signatureId, newEmailAddress);
+        String newSignerName = "Night Man";
+        client.updateSignatureRequest(id, signatureId, newEmailAddress, newSignerName);
     }
 
     @Test


### PR DESCRIPTION
The HS API now supports changing the name associated with signatures in addition to the email address (https://app.hellosign.com/api/reference#update_signature_request). This allows the SDK to make use of that functionality.